### PR TITLE
Update uacadastre.js

### DIFF
--- a/components/leaflet.geomanager/providers/uacadastre.js
+++ b/components/leaflet.geomanager/providers/uacadastre.js
@@ -46,7 +46,7 @@ L.GeoManager.UACadastreIdentify = function (options) {
         .done(function(data){
             if (data) {
                 var $xml = $(data)
-                    , original_coords = $xml.find('gml\\:coordinates').text().split(' ')
+                    , original_coords = $xml.find('gml\\:coordinates, coordinates').text().split(' ')
                     , koatuu = $xml.find('dzk\\:koatuu').text()       
                     , zone = $xml.find('dzk\\:zona').text()  
                     , quartal = $xml.find('dzk\\:kvartal').text() 


### PR DESCRIPTION
фикс исправляет ошибку парсинга xml для Хрома, но в цикле какае-то ошибка создания coords для L.Polygon - по прежнему не работает popup для Хрома.
